### PR TITLE
scene merge - pyramid normalisation - doc metadata

### DIFF
--- a/Src/RemoveScenes/main.cpp
+++ b/Src/RemoveScenes/main.cpp
@@ -5,18 +5,86 @@
 using namespace std;
 using namespace libCZI;
 
-static void RemoveSIndex(const std::shared_ptr<ICziReaderWriter>& reader_writer, int index, const SubBlockInfo& info)
+/**
+ * Normalizes the pyramids within a scene to have the same 'height' i.e. the same minimum zoom and the same number of zoom levels.
+ *
+ * @param reader_writer A shared pointer to an ICziReaderWriter object.
+ *
+ * Note: This function may discard image data at lower zoom levels while it is only the lower resolution image data which is discarded
+ * and this image data can be recovered from the more detailed data at higher zooms.
+ */
+static void NormaliseScenePyramids(const std::shared_ptr<ICziReaderWriter>& reader_writer)
+{
+    std::cout << "Performing pyramid normalisation" << std::endl;
+
+    // Do an initial pass of all the blocks, figuring out what is the ‘height’ of each pyramid (minimumZoomPerScene)
+    std::map<int, double> minimumZoomPerScene;
+    reader_writer->EnumerateSubBlocks(
+        [&](int index, const SubBlockInfo& info) -> bool
+    {
+        libCZI::CDimCoordinate coord = info.coordinate;
+        int sValue;
+        if (coord.TryGetPosition(DimensionIndex::S, &sValue))
+        {
+            double zoom = info.GetZoom();
+            // Check if sValue is already in minimumZoomPerScene and if zoom is smaller
+            auto it = minimumZoomPerScene.find(sValue);
+            if (it == minimumZoomPerScene.end() || it->second > zoom) // if not found or found with a larger zoom
+            {
+                minimumZoomPerScene[sValue] = zoom; // Update with the new smaller zoom
+            }
+        }
+        return true;
+    });
+
+    // Figure out which pyramid is the shortest (minimumCommonZoom)
+    double minimumCommonZoom = 0;
+    for(const auto& pair : minimumZoomPerScene) {
+        std::cout << "Scene: " << pair.first << ", Minimum Zoom: " << pair.second << std::endl;
+        if(pair.second > minimumCommonZoom){
+            minimumCommonZoom = pair.second;
+        }
+    }
+    std::cout << "Minimum Common Zoom : " << minimumCommonZoom << std::endl;
+
+    // Do another pass of the blocks and mark for removal, any blocks which are zoomed out more than this value.
+    std::vector<int> indexesToRemove;
+    reader_writer->EnumerateSubBlocks(
+        [&](int index, const SubBlockInfo& info) ->bool
+    {
+        double zoom = info.GetZoom();
+        if(zoom<minimumCommonZoom){ 
+            std::cout << "Marking subblock for removal Index " << index << " Zoom " << zoom << ": " << libCZI::Utils::DimCoordinateToString(&info.coordinate) << " Rect=" << info.logicalRect << " PhysicalSize=" << info.physicalSize << std::endl;
+            indexesToRemove.push_back(index); 
+        }
+        return true;
+    });
+
+    // Finally, do the actual sub block removal.  Note that this is done out of the EnumerateSubBlocks loop to avoid a segmentation fault
+    if(!indexesToRemove.empty()){
+        std::cout << "Removing sub blocks" << std::endl;
+        for(int index : indexesToRemove) {
+            reader_writer->RemoveSubBlock(index);
+        }
+    }
+}
+
+/**
+ * Update the S dimension and m index of a block.
+ *
+ * @param reader_writer A shared pointer to an ICziReaderWriter object.
+ * @param index The index of the block as seen by the reader.
+ * @param info Sub Block info for the block.
+ */
+static void MergeSIndex(const std::shared_ptr<ICziReaderWriter>& reader_writer, int index, const SubBlockInfo& info)
 {
     AddSubBlockInfo add_sub_block_info;
     add_sub_block_info.Clear();
     add_sub_block_info.coordinate = info.coordinate;
-    add_sub_block_info.coordinate.Clear(DimensionIndex::S);
+    add_sub_block_info.coordinate.Set(DimensionIndex::S,0); //Set all Scenes to 0, effectively 'merging' the scenes into one
 
-    // we also set the m-index to invalid - we would have to re-create an m-index scheme when removing the S-index,
-    //  because "m-index is scene-scoped". So, in order to have a well-formed CZI, we'd need to re-create the m-index.
-    //  We don't do this here (yet), and I reckon it is better to have no m-index than an invalid one.
-    add_sub_block_info.mIndexValid = false;
-    add_sub_block_info.mIndex = numeric_limits<int>::max();
+    add_sub_block_info.mIndexValid = true;
+    add_sub_block_info.mIndex = index;  //reset mIndex using the index of the block enumeration
     add_sub_block_info.x = info.logicalRect.x;
     add_sub_block_info.y = info.logicalRect.y;
     add_sub_block_info.logicalWidth = info.logicalRect.w;
@@ -74,6 +142,32 @@ static void RemoveSIndex(const std::shared_ptr<ICziReaderWriter>& reader_writer,
     reader_writer->ReplaceSubBlock(index, add_sub_block_info);
 }
 
+/**
+ * Update document metadata to indicate the new size of the S dimension (1) and add a comment indicating the file has been merged.
+ *
+ * @param reader_writer A shared pointer to an ICziReaderWriter object.
+ */
+static void UpdateMetadata(const std::shared_ptr<ICziReaderWriter>& reader_writer){
+    std::cout << "Updating document metadata" << std::endl;
+    const auto metadata_segment = reader_writer->ReadMetadataSegment();
+    const auto metadata = metadata_segment->CreateMetaFromMetadataSegment();
+    const auto metadata_builder = CreateMetadataBuilderFromXml(metadata->GetXml());
+
+    const auto comment_node = metadata_builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Document/Comment");
+    comment_node->SetValue("The scenes in this file have been merged post-instrument");
+
+    const auto size_s_node = metadata_builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Image/SizeS");
+    size_s_node->SetValue("1");
+
+    WriteMetadataInfo metadata_info;
+    metadata_info.Clear();
+    const string source_metadata_xml = metadata_builder->GetXml();
+    metadata_info.szMetadata = source_metadata_xml.c_str();
+    metadata_info.szMetadataSize = source_metadata_xml.size();
+    reader_writer->SyncWriteMetadata(metadata_info);
+}
+
+
 int main()
 {
     std::cout << "Opening input/output stream" << std::endl;
@@ -85,12 +179,20 @@ int main()
     // open the CZI-file
     reader_writer->Create(io_stream);
 
+    // normalise scene pyramids so they all have the same number of zoom levels
+    NormaliseScenePyramids(reader_writer);
+
+    // merge the scenes by setting the S index of all sub blocks to 0
+    std::cout << "Merging scenes" << std::endl;
     reader_writer->EnumerateSubBlocks(
         [&](int index, const SubBlockInfo& info) ->bool
     {
-        RemoveSIndex(reader_writer, index, info);
+        MergeSIndex(reader_writer, index, info);
         return true;
     });
+
+    // update the document metadata so FIJI and CZICheck are happy
+    UpdateMetadata(reader_writer);
 
     reader_writer->Close();
 

--- a/Src/RemoveScenes/main.cpp
+++ b/Src/RemoveScenes/main.cpp
@@ -167,11 +167,27 @@ static void UpdateMetadata(const std::shared_ptr<ICziReaderWriter>& reader_write
     reader_writer->SyncWriteMetadata(metadata_info);
 }
 
-
-int main()
+const wchar_t *GetWC(const char *c)
 {
+    const size_t cSize = strlen(c)+1;
+    wchar_t* wc = new wchar_t[cSize];
+    mbstowcs (wc, c, cSize);
+
+    return wc;
+}
+
+int main(int argc, char* _argv[])
+{
+    if(argc != 2){
+        std::cout << "Usage: " << _argv[0] << " path/to/my/file.czi" << std::endl;
+        return 1;
+    }
+
+    std::cout << "Merging file" << _argv[1] << std::endl;
+    auto filePath = GetWC(_argv[1]);
+
     std::cout << "Opening input/output stream" << std::endl;
-    const auto io_stream = libCZI::CreateInputOutputStreamForFile(LR"(D:\Data\CZI\libczi#94\test.czi)");
+    const auto io_stream = libCZI::CreateInputOutputStreamForFile(filePath);
 
     // create the reader-writer-object
     auto reader_writer = libCZI::CreateCZIReaderWriter();


### PR DESCRIPTION
# STOP - Read this First!
Reporting a security vulnerability?  
Check out the project's [security policy](https://github.com/zeiss/libczi/security/policy).

# Fill out and Adjust this Template

## Description

Summary of the change(s) and which issue(s) is/are fixed  
changed removal of the S Dimension to a 'merge' of the S dimension to 0 i.e. a single scene
used enum index to set mIndex
added normalisation of pyramids using 'chop the top off' method
updated document metadata

Relevant motivation and context  
these changes produce a file that is importable into Omero, loadable in Fiji and passes CZICheck

Dependencies required for this change  
No Additional dependencies

Fixes # (issue)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.  
I converted some test files.
Provide instructions to reproduce.

## Checklist:

- [ ] I followed the Contributing Guidelines.
- [ ] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
